### PR TITLE
add custom header support

### DIFF
--- a/src/bin/mcp-proxy.rs
+++ b/src/bin/mcp-proxy.rs
@@ -10,7 +10,7 @@ use rmcp_proxy::{
 };
 use std::{collections::HashMap, env, error::Error, net::SocketAddr, time::Duration};
 use tracing::debug;
-use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 /// MCP Proxy CLI arguments
 #[derive(Parser)]

--- a/src/proxy_handler.rs
+++ b/src/proxy_handler.rs
@@ -2,12 +2,12 @@
  * Create a local SSE server that proxies requests to a stdio MCP server.
  */
 use rmcp::{
-    Error, RoleClient, RoleServer, ServerHandler,
     model::{
         CallToolRequestParam, CallToolResult, ClientInfo, Content, Implementation, ListToolsResult,
         PaginatedRequestParam, ServerInfo,
     },
     service::{RequestContext, RunningService},
+    Error, RoleClient, RoleServer, ServerHandler,
 };
 use std::sync::Arc;
 use tokio::sync::Mutex;

--- a/src/sse_server.rs
+++ b/src/sse_server.rs
@@ -3,12 +3,12 @@ use crate::proxy_handler::ProxyHandler;
  * Create a local SSE server that proxies requests to a stdio MCP server.
  */
 use rmcp::{
-    ServiceExt,
     model::{ClientCapabilities, ClientInfo},
     transport::{
         child_process::TokioChildProcess,
         sse_server::{SseServer, SseServerConfig},
     },
+    ServiceExt,
 };
 use std::{collections::HashMap, error::Error as StdError, net::SocketAddr, time::Duration};
 use tokio::process::Command;


### PR DESCRIPTION
Official rust MCP SDK now supports passing in a custom reqwest Client, allowing us to set default headers that are set on each request.